### PR TITLE
Added resource-links and fixed the repo link

### DIFF
--- a/getting started.html
+++ b/getting started.html
@@ -61,8 +61,8 @@
     </ul>
     <div class="new_para" style="padding-top: 30px; padding-bottom: 40px;">Do you know better resources that are not
         included on this page? Add them here:
-        <a href="git@github.com:anup/codechef-resources.git">git@github.com:anup/codechef-resources.git.</a>
-        Just fork the repo and send us a <a href="https://help.github.com/articles/using-pull-requests">pull request</a>.
+        <b>git@github.com:anup/codechef-resources.git</b>.
+        Just <a href="https://github.com/anup/codechef-resources">fork the repo</a> and send us a <a href="https://help.github.com/articles/using-pull-requests">pull request</a>.
         We will also be happy to add Collaborators to the projects. Feel free to edit the "getting started.html" file
         and start contributing. If you face any issue send us an <a href="mailto:feedback@codechef.com">email</a>.
     </div>


### PR DESCRIPTION
I have added 3 resource-links and fixed the link to the github repo. Instead of git url, the web link now opens the github home page of the project, for forking.

Please review my changes and let me know if there is any problem.

Thanks :)
