### PR TITLE
Basic Linux Command Lines 1 & 2 removed.

### DIFF
--- a/getting started.html
+++ b/getting started.html
@@ -87,8 +87,6 @@
 <div class="header header_h2" id='learn_linux'>Learn Linux</div>
 <ul class="ulstyle-block ul_padding_nil clear">
 <li><a href="https://github.com/aleksandar-todorovic/awesome-linux">Awesome Linux</a></li>
-<li><a href="http://www.efytimes.com/e1/fullnews.asp?edid=112641">Basic Linux Command Lines</a></li>
-<li><a href="http://www.efytimes.com/e1/fullnews.asp?edid=112869">Basic Linux Command Lines 2</a></li>
 <li><a href="http://sunburn.stanford.edu/~nick/compdocs/Programming_on_Unix.pdf">UNIX Programming Tools</a></li>
 </ul>
     <div class="header header_h2" id='practice_other_sites'>Practice on other sites:</div>


### PR DESCRIPTION
Basic Linux Command Lines 1 & 2 removed. This is because they were leading to some Commercial website about watches.
Somebody added it for their own promotion. Here are the old URLs:
1. http://electronicsforu.com/market-verticals/wearable-technology?edid=112869
2. http://electronicsforu.com/market-verticals/wearable-technology?edid=112641

Please check the links before publishing. Thanks. 😄 