### PR TITLE
Update page links

### DIFF
--- a/getting started.html
+++ b/getting started.html
@@ -37,7 +37,7 @@
 <li><a href="http://en.wikipedia.org/wiki/Introduction_to_Algorithms">Introduction to Algorithms</a></li>
 <li><a href="http://www.codecademy.com/afterschool/">Codecademy</a></li>
 <li><a href="https://www.udacity.com/">Udacity</a></li>
-<li><a href="http://nptel.iitm.ac.in/video.php?subjectId=106102064">NPTEL-Data Structures And Algorithms(IIT Delhi)</a></li>
+<li><a href="https://nptel.ac.in/courses/106102064/">NPTEL-Data Structures And Algorithms(IIT Delhi)</a></li>
 <li><a href="http://playcodemonkey.com/">CodeMonkey - Write Code. Catch Bananas. Save the World</a></li>
 </ul>
 <div class="header header_h2" id='learn_ds_n_algo'>Learn Data Structures &amp; Algorithms</div>
@@ -49,17 +49,17 @@
 </ul>
 <div class="header header_h2" id='learn_ds_n_algo'>Competitive programming references for competitions</div>
 <ul class="ulstyle-block ul_padding_nil clear">
-<li><a href="http://web.stanford.edu/~liszt90/acm/notebook.html">Stanford Team Notebook</a></li>
+<li><a href="https://cs.stanford.edu/group/acm/SLPC/notebook.pdf">Stanford ICPC Team Notebook</a></li>
 <li><a href="http://comscigate.com/Books/contests/icpc.pdf">Hitchhiker's Guide to Programming Contests</a></li>
 </ul>
-<div class="header header_h2" id='programming_jewels'>Some Programming Jewels to get your started:</div>
+<div class="header header_h2" id='programming_jewels'>Some Programming Jewels to get you started:</div>
 <ul class="ulstyle-block ul_padding_nil clear">
 <li><a href="http://dhruvbird.com/61.html">Anyone Can Code</a></li>
 <li><a href="http://www.stanford.edu/class/cs97si/">Introduction to Competitive Programming Contests</a></li>
 <li> <a href="https://docs.google.com/document/d/1MlbFmE6ji3Yb6mNmZDHcNIBiZzlhzf31iz2wUe3iS0M/edit?authkey=COyc9Uc">List                 of Topics for programming Competitions</a></li>
 <li> <a href="http://ocw.mit.edu/courses/electrical-engineering-and-computer-science/6-046j-introduction-to-algorithms-sma-5503-fall-2005/video-lectures/">MIT                 Open Courseware: Video lectures</a></li>
 <li><a href="http://www.cs.sunysb.edu/~algorith/video-lectures/">Skiena's Algorithms Lectures</a></li>
-<li><a href="http://www.topcoder.com/tc?d1=tutorials&d2=alg_index&module=Static"> Topcoder Algorithm Tutorials</a></li>
+<li><a href="https://drive.google.com/open?id=1eoTHYc0wDK3OyQc9INrnGSeE4k3sJ7X8"> Topcoder Algorithm Tutorials</a></li>
 </ul>
 <div class="header header_h2" id='wikibook_links'>Wikibooks links:</div>
 <ul class="ulstyle-block ul_padding_nil clear">
@@ -72,14 +72,15 @@
 <li><a href="https://github.com/fffaraz/awesome-cpp">Awesome C++</a></li>
 <li><a href="http://www.icce.rug.nl/documents/cplusplus/">The C++ Annotations</a></li>
 <li><a href="http://en.cppreference.com/">C++ Reference</a></li>
-<li><a href="http://sunburn.stanford.edu/~nick/compdocs/Essential_C.pdf">Essential C - Important C Concepts</a></li>
-<li><a href="http://sunburn.stanford.edu/~nick/compdocs/Essential_C++.pdf">Essential C++ - Important C++ and OOPs Concepts</a></li>
+<li><a href="http://cslibrary.stanford.edu/101/EssentialC.pdf">Essential C - Important C Concepts</a></li>
+<li><a href="http://web.stanford.edu/class/cs106l/handouts/full_course_reader.pdf">Essential C++ - Important C++ and OOPs Concepts</a></li>
 <li><a href="http://cslibrary.stanford.edu/106/">Pointers in C Basics</a></li>
 <li><a href="http://cslibrary.stanford.edu/102/PointersAndMemory.pdf">Pointers and Memory - Types, Allocation in C/C++</a></li>
 <li><a href="http://www.cplusplus.com/reference/stl/">STL Documentation</a></li>
     <li><a href="http://www.cplusplus.com/reference/algorithm/">STL-Algorithm Documentation</a></li>
-    <li><a href="https://www.topcoder.com/community/data-science/data-science-tutorials/power-up-c-with-the-standard-template-library-part-1/">TopCoder STL Tutorial Part 1</a></li>
-    <li><a href="https://www.topcoder.com/community/data-science/data-science-tutorials/power-up-c-with-the-standard-template-library-part-2/">TopCoder STL Tutorial Part 2</a></li>
+    <li><a href ="http://squall.cs.ntou.edu.tw/cpp/1052/slides/CPP04-STLAlgorithms_4up.pdf">Complete STL guide</a></li>
+    <li><a href="http://read.pudn.com/downloads151/doc/658714/Power_up_CPP_STL.pdf">TopCoder STL Tutorial Part 1</a></li>
+    <li><a href="https://community.topcoder.com/tc?module=Static&d1=features&d2=082803">TopCoder STL Tutorial Part 2</a></li>
     <li><a href="https://github.com/akullpp/awesome-java">Awesome Java</a></li>
 <li><a href="https://github.com/vinta/awesome-python">Awesome Python</a></li>
 </ul>
@@ -87,14 +88,12 @@
 <div class="header header_h2" id='learn_linux'>Learn Linux</div>
 <ul class="ulstyle-block ul_padding_nil clear">
 <li><a href="https://github.com/aleksandar-todorovic/awesome-linux">Awesome Linux</a></li>
-<li><a href="http://www.efytimes.com/e1/fullnews.asp?edid=112641">Basic Linux Command Lines</a></li>
-<li><a href="http://www.efytimes.com/e1/fullnews.asp?edid=112869">Basic Linux Command Lines 2</a></li>
-<li><a href="http://sunburn.stanford.edu/~nick/compdocs/Programming_on_Unix.pdf">UNIX Programming Tools</a></li>
+<li><a href="http://cslibrary.stanford.edu/107/UnixProgrammingTools.pdf">UNIX Programming Tools</a></li>
 </ul>
     <div class="header header_h2" id='practice_other_sites'>Practice on other sites:</div>
 <ul class="ulstyle-block ul_padding_nil clear">
 <li><a href="http://www.iarcs.org.in/inoi/">Indian Computing Olympiad</a></li>
-<li><a href="http://cerberus.delos.com:790/usacogate">Usaco Training Program</a></li>
+<li><a href="http://www.usaco.org/index.php?page=training">Usaco Training Program</a></li>
 </ul>
 <div class="header header_h2" id='other_resources'>Other Resources</div>
  <ul class="ulstyle-block ul_padding_nil clear">


### PR DESCRIPTION
Here is a summary of the changes suggested under( all links as mentioned were not functional):

**learn to program** : nptel link

**competitive programming reference for competitions**: stanford icpc notebook link

**some programming jewels to get you started**: Topcoder link

**language specific**: essential C,C++,Topcoder STL tutorial link. I also made a suggestion for a new guide

**learn linux**: UNIX commands link, two extra links on the source page

**practice on other sites**: USACO training program link

I have corrected these links with the most relevant ones

Fixes #25 